### PR TITLE
Wrap methods which implement IDisposable in using()

### DIFF
--- a/PasswordHash.cs
+++ b/PasswordHash.cs
@@ -72,15 +72,16 @@ namespace PasswordHash
         public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTE_SIZE, int hashBytes = HASH_BYTE_SIZE)
         {
             // Generate a random salt
-            RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[saltBytes];
-            csprng.GetBytes(salt);
+            using (RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider()) {
+                byte[] salt = new byte[saltBytes];
+                csprng.GetBytes(salt);
 
-            // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
-            return pbkdf2Iterations + ":" +
-                Convert.ToBase64String(salt) + ":" +
-                Convert.ToBase64String(hash);
+                // Hash the password and encode the parameters
+                byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+                return pbkdf2Iterations + ":" +
+                    Convert.ToBase64String(salt) + ":" +
+                    Convert.ToBase64String(hash);
+            }
         }
 
         /// <summary>
@@ -128,9 +129,10 @@ namespace PasswordHash
         /// <returns>A hash of the password.</returns>
         private static byte[] PBKDF2(string password, byte[] salt, int iterations, int outputBytes)
         {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt);
-            pbkdf2.IterationCount = iterations;
-            return pbkdf2.GetBytes(outputBytes);
+            using (Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt)) {
+                pbkdf2.IterationCount = iterations;
+                return pbkdf2.GetBytes(outputBytes);
+            }
         }
     }
 } 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+password-hashing
+================
+
+Fork of https://github.com/defuse/password-hashing.
+
+The intent of this fork is to:
+    * enable configurability of pbkdf2 iteration count and salt size without requiring recompilation
+    * Address and document issue that gives an attacker an additional advantage over defender (in addition to typical hardware advantages the attacker already has), as described at http://security.stackexchange.com/a/51430/28362

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ password-hashing
 Fork of https://github.com/defuse/password-hashing.
 
 The intent of this fork is to:
-    * enable configurability of pbkdf2 iteration count and salt size without requiring recompilation
-    * Address and document issue that gives an attacker an additional advantage over defender (in addition to typical hardware advantages the attacker already has), as described at http://security.stackexchange.com/a/51430/28362
+
+ * enable configurability of pbkdf2 iteration count and salt size without requiring recompilation
+ * Address and document issue that gives an attacker an additional advantage over defender (in addition to typical hardware advantages the attacker already has), as described at http://security.stackexchange.com/a/51430/28362 and demonstrated at https://gist.github.com/davisnw/991912f1a6fe2b63a73b

--- a/compatible/PasswordHash.cs
+++ b/compatible/PasswordHash.cs
@@ -72,15 +72,16 @@ namespace PasswordHash
         public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTES, int hashBytes = HASH_BYTES)
         {
             // Generate a random salt
-            RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[saltBytes];
-            csprng.GetBytes(salt);
+            using (RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider()) {
+                byte[] salt = new byte[saltBytes];
+                csprng.GetBytes(salt);
 
-            // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
-            return pbkdf2Iterations + ":" +
-                Convert.ToBase64String(salt) + ":" +
-                Convert.ToBase64String(hash);
+                // Hash the password and encode the parameters
+                byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+                return pbkdf2Iterations + ":" +
+                    Convert.ToBase64String(salt) + ":" +
+                    Convert.ToBase64String(hash);
+            }
         }
 
         /// <summary>
@@ -128,9 +129,10 @@ namespace PasswordHash
         /// <returns>A hash of the password.</returns>
         private static byte[] PBKDF2(string password, byte[] salt, int iterations, int outputBytes)
         {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt);
-            pbkdf2.IterationCount = iterations;
-            return pbkdf2.GetBytes(outputBytes);
+            using (Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt)) {
+                pbkdf2.IterationCount = iterations;
+                return pbkdf2.GetBytes(outputBytes);
+            }
         }
     }
 }


### PR DESCRIPTION
RNGCryptoServiceProvider and Rfc2898DeriveBytes both implement
[IDisposable](https://msdn.microsoft.com/en-us/library/system.idisposable.aspx)
so should be wrapped in using() or .Dispose()'d.
