### PR TITLE
Wrap IDisposable calls in using()

### DIFF
--- a/PasswordHash.cs
+++ b/PasswordHash.cs
@@ -40,30 +40,45 @@ namespace PasswordHash
     /// </summary>
     public class PasswordHash
     {
+        /// <summary>
+        /// The underlying BLOCK_SIZE of the pbkdf2 implementation.  As of 2014-07-20, the
+        /// .NET Framework implementation uses SHA1, which has a block size of 20.
+        /// </summary>
+        public const int BLOCK_SIZE = 20;
+
         // The following constants may be changed without breaking existing hashes.
         public const int SALT_BYTE_SIZE = 24;
-        public const int HASH_BYTE_SIZE = 24;
+        /// <summary>
+        /// HASH_BYTE_SIZE should *not* be greater than <see cref="BLOCK_SIZE"/>.  A HASH_BYTE_SIZE greater than block size makes
+        /// the defender's job more difficult, without making the attackers job more difficult, because the defender
+        /// must calculate all blocks, but the attacker only has to check the first block.  Instead,
+        /// increase the iteration count and salt size to make the attacker's job more difficult.
+        /// </summary>
+        public const int HASH_BYTE_SIZE = BLOCK_SIZE;
         public const int PBKDF2_ITERATIONS = 1000;
 
         public const int ITERATION_INDEX = 0;
         public const int SALT_INDEX = 1;
         public const int PBKDF2_INDEX = 2;
-              
+
         /// <summary>
         /// Creates a salted PBKDF2 hash of the password.
         /// </summary>
         /// <param name="password">The password to hash.</param>
+        /// <param name="pbkdf2Iterations">The number of iterations of the pbkdf2 algorithm. Higher numbers take longer to create and validate, and are thus harder to crack.</param>
+        /// <param name="saltBytes">The length of the salt in bytes. As a rule of thumb, the salt should be at least as long as <see cref="hashBytes"/>.</param>
+        /// <param name="hashBytes">The length of the final password hash in bytes. This should *not* exceed <see cref="BLOCK_SIZE"/>.</param>
         /// <returns>The hash of the password.</returns>
-        public static string CreateHash(string password)
+        public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTE_SIZE, int hashBytes = HASH_BYTE_SIZE)
         {
             // Generate a random salt
             RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[SALT_BYTE_SIZE];
+            byte[] salt = new byte[saltBytes];
             csprng.GetBytes(salt);
 
             // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, PBKDF2_ITERATIONS, HASH_BYTE_SIZE);
-            return PBKDF2_ITERATIONS + ":" +
+            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+            return pbkdf2Iterations + ":" +
                 Convert.ToBase64String(salt) + ":" +
                 Convert.ToBase64String(hash);
         }

--- a/PasswordHash.cs
+++ b/PasswordHash.cs
@@ -72,15 +72,16 @@ namespace PasswordHash
         public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTE_SIZE, int hashBytes = HASH_BYTE_SIZE)
         {
             // Generate a random salt
-            RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[saltBytes];
-            csprng.GetBytes(salt);
+            using (RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider()) {
+                byte[] salt = new byte[saltBytes];
+                csprng.GetBytes(salt);
 
-            // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
-            return pbkdf2Iterations + ":" +
-                Convert.ToBase64String(salt) + ":" +
-                Convert.ToBase64String(hash);
+                // Hash the password and encode the parameters
+                byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+                return pbkdf2Iterations + ":" +
+                    Convert.ToBase64String(salt) + ":" +
+                    Convert.ToBase64String(hash);
+            }
         }
 
         /// <summary>
@@ -128,9 +129,10 @@ namespace PasswordHash
         /// <returns>A hash of the password.</returns>
         private static byte[] PBKDF2(string password, byte[] salt, int iterations, int outputBytes)
         {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt);
-            pbkdf2.IterationCount = iterations;
-            return pbkdf2.GetBytes(outputBytes);
+            using (Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt)) {
+                pbkdf2.IterationCount = iterations;
+                return pbkdf2.GetBytes(outputBytes);
+            }
         }
     }
 } 

--- a/compatible/PasswordHash.cs
+++ b/compatible/PasswordHash.cs
@@ -40,9 +40,21 @@ namespace PasswordHash
     /// </summary>
     class PasswordHash
     {
+        /// <summary>
+        /// The underlying BLOCK_SIZE of the pbkdf2 implementation.  As of 2014-07-20, the
+        /// .NET Framework implementation uses SHA1, which has a block size of 20.
+        /// </summary>
+        public const int BLOCK_SIZE = 20;
+
         // The following constants may be changed without breaking existing hashes.
         public const int SALT_BYTES = 24;
-        public const int HASH_BYTES = 24;
+        /// <summary>
+        /// HASH_BYTES should *not* be greater than <see cref="BLOCK_SIZE"/>.  A HASH_BYTE_SIZE greater than block size makes
+        /// the defender's job more difficult, without making the attackers job more difficult, because the defender
+        /// must calculate all blocks, but the attacker only has to check the first block.  Instead,
+        /// increase the iteration count and salt size to make the attacker's job more difficult.
+        /// </summary>
+        public const int HASH_BYTES = BLOCK_SIZE;
         public const int PBKDF2_ITERATIONS = 1000;
 
         public const int ITERATION_INDEX = 1;
@@ -53,17 +65,20 @@ namespace PasswordHash
         /// Creates a salted PBKDF2 hash of the password.
         /// </summary>
         /// <param name="password">The password to hash.</param>
+        /// <param name="pbkdf2Iterations">The number of iterations of the pbkdf2 algorithm. Higher numbers take longer to create and validate, and are thus harder to crack.</param>
+        /// <param name="saltBytes">The length of the salt in bytes. As a rule of thumb, the salt should be at least as long as <see cref="hashBytes"/>.</param>
+        /// <param name="hashBytes">The length of the final password hash in bytes. This should *not* exceed <see cref="BLOCK_SIZE"/>.</param>
         /// <returns>The hash of the password.</returns>
-        public static string CreateHash(string password)
+        public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTES, int hashBytes = HASH_BYTES)
         {
             // Generate a random salt
             RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[SALT_BYTES];
+            byte[] salt = new byte[saltBytes];
             csprng.GetBytes(salt);
 
             // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, PBKDF2_ITERATIONS, HASH_BYTES);
-            return "sha1:" + PBKDF2_ITERATIONS + ":" +
+            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+            return pbkdf2Iterations + ":" +
                 Convert.ToBase64String(salt) + ":" +
                 Convert.ToBase64String(hash);
         }

--- a/compatible/PasswordHash.cs
+++ b/compatible/PasswordHash.cs
@@ -72,15 +72,16 @@ namespace PasswordHash
         public static string CreateHash(string password, int pbkdf2Iterations = PBKDF2_ITERATIONS, int saltBytes = SALT_BYTES, int hashBytes = HASH_BYTES)
         {
             // Generate a random salt
-            RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider();
-            byte[] salt = new byte[saltBytes];
-            csprng.GetBytes(salt);
+            using (RNGCryptoServiceProvider csprng = new RNGCryptoServiceProvider()) {
+                byte[] salt = new byte[saltBytes];
+                csprng.GetBytes(salt);
 
-            // Hash the password and encode the parameters
-            byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
-            return pbkdf2Iterations + ":" +
-                Convert.ToBase64String(salt) + ":" +
-                Convert.ToBase64String(hash);
+                // Hash the password and encode the parameters
+                byte[] hash = PBKDF2(password, salt, pbkdf2Iterations, hashBytes);
+                return pbkdf2Iterations + ":" +
+                    Convert.ToBase64String(salt) + ":" +
+                    Convert.ToBase64String(hash);
+            }
         }
 
         /// <summary>
@@ -128,9 +129,10 @@ namespace PasswordHash
         /// <returns>A hash of the password.</returns>
         private static byte[] PBKDF2(string password, byte[] salt, int iterations, int outputBytes)
         {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt);
-            pbkdf2.IterationCount = iterations;
-            return pbkdf2.GetBytes(outputBytes);
+            using (Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, salt)) {
+                pbkdf2.IterationCount = iterations;
+                return pbkdf2.GetBytes(outputBytes);
+            }
         }
     }
 }


### PR DESCRIPTION
RNGCryptoServiceProvider and Rfc2898DeriveBytes both implement [IDisposable](https://msdn.microsoft.com/en-us/library/system.idisposable.aspx) so should be wrapped in `using()` or `.dispose()`'d.
